### PR TITLE
Make `format` smart about multiline messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ log(command("task", "logissue", { type: "error" })("Error summary"));
 log(format("error")(
     "Details about error.",
     "Second line of details.",
-    "Third line.",
+    "Third and\nfourth line.",
 ));
 
 /*
@@ -35,7 +35,8 @@ Output:
 ##vso[task.logissue type=error;]Error summary
 ##[error]Details about error.
 ##[error]Second line of details.
-##[error]Third line.
+##[error]Third and
+##[error]fourth line.
 */
 
 ```

--- a/docs/examples/basic.ts
+++ b/docs/examples/basic.ts
@@ -4,7 +4,7 @@ log(command("task", "logissue", { type: "error" })("Error summary"));
 log(format("error")(
     "Details about error.",
     "Second line of details.",
-    "Third line.",
+    "Third and\nfourth line.",
 ));
 
 /*
@@ -12,5 +12,6 @@ Output:
 ##vso[task.logissue type=error;]Error summary
 ##[error]Details about error.
 ##[error]Second line of details.
-##[error]Third line.
+##[error]Third and
+##[error]fourth line.
 */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -33,14 +33,16 @@ describe(command, () => {
 
 describe(format, () => {
     it("command", () => {
-        const actual = format("command")("Command-line being run");
-        const expected = `##[command]Command-line being run`;
+        const actual = format("command")("Command-line being run", "Next line", "Multiple\nLines");
+        const expected = `##[command]Command-line being run\n##[command]Next line\n##[command]Multiple\n##[command]Lines`;
         expect(actual).toEqual(expected);
+        expect(format("command")()).toEqual("##[command]");
     });
     it("debug", () => {
-        const actual = format("debug")("Debug text", "Next line");
-        const expected = `##[debug]Debug text\n##[debug]Next line`;
+        const actual = format("debug")("Debug text", "Next line", "Multiple\nLines");
+        const expected = `##[debug]Debug text\n##[debug]Next line\n##[debug]Multiple\n##[debug]Lines`;
         expect(actual).toEqual(expected);
+        expect(format("debug")()).toEqual("##[debug]");
     });
     it("endgroup", () => {
         const actual = format("endgroup")();
@@ -48,9 +50,10 @@ describe(format, () => {
         expect(actual).toEqual(expected);
     });
     it("error", () => {
-        const actual = format("error")("Error message", "Next line");
-        const expected = `##[error]Error message\n##[error]Next line`;
+        const actual = format("error")("Error message", "Next line", "Multiple\nLines");
+        const expected = `##[error]Error message\n##[error]Next line\n##[error]Multiple\n##[error]Lines`;
         expect(actual).toEqual(expected);
+        expect(format("error")()).toEqual("##[error]");
     });
     it("group", () => {
         const actual = format("group")("Beginning of a group");
@@ -58,9 +61,10 @@ describe(format, () => {
         expect(actual).toEqual(expected);
     });
     it("warning", () => {
-        const actual = format("warning")("Warning message", "Next line");
-        const expected = `##[warning]Warning message\n##[warning]Next line`;
+        const actual = format("warning")("Warning message", "Next line", "Multiple\nLines");
+        const expected = `##[warning]Warning message\n##[warning]Next line\n##[warning]Multiple\n##[warning]Lines`;
         expect(actual).toEqual(expected);
+        expect(format("warning")()).toEqual("##[warning]");
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,9 @@ import {
 } from "./internal/command";
 import {
     Format,
-    FormatWithSingleLineMessage,
-    FormatWithMultiLineMessage,
+    FormatWithMessage,
     FormatWithoutMessage,
 } from "./internal/format";
-import {
-    NonEmptyArray,
-} from "./internal/utilities";
 
 /**
  * Constructs a general log command.
@@ -43,11 +39,11 @@ export function command<
  * Constructs a formatting log command representing an error, warning, collapsible section etc.
  */
 export function format(format: FormatWithoutMessage): () => string;
-export function format(format: FormatWithSingleLineMessage): (message: string) => string;
-export function format(format: FormatWithMultiLineMessage): (...message: NonEmptyArray<string>) => string;
+export function format(format: FormatWithMessage): (...message: readonly string[]) => string;
 export function format(format: Format): (...message: readonly string[]) => string {
     return (...message) => (
-        (message.length === 0 ? [""] : message) // The empty list represents the FormatWithoutMessage case.
+        // Arguments are conceptually treated as lines, but since they themselves can contain line breaks, we first split each argument into lines.
+        (message.length === 0 ? [""] : message.flatMap(arg => arg.split("\n")))
         .map(line => `##[${format}]${line}`)
         .join("\n")
     );

--- a/src/internal/format.ts
+++ b/src/internal/format.ts
@@ -1,8 +1,6 @@
-export type FormatWithSingleLineMessage = "command" | "group";
-
-export type FormatWithMultiLineMessage = "debug" | "error" | "warning";
+export type FormatWithMessage = "command" | "debug" | "error" | "group" | "warning";
 
 export type FormatWithoutMessage = "endgroup";
 
 // https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands#formatting-commands
-export type Format = FormatWithSingleLineMessage | FormatWithMultiLineMessage | FormatWithoutMessage;
+export type Format = FormatWithMessage | FormatWithoutMessage;

--- a/src/internal/utilities.ts
+++ b/src/internal/utilities.ts
@@ -1,1 +1,0 @@
-export type NonEmptyArray<T> = [T, ...T[]];


### PR DESCRIPTION
Before, there were three cases, depending on the format used:

  * `endgroup`:                  no argument
  * `command`, `group`:          one argument
  * `debug`, `error`, `warning`: one or more arguments

Each argument became one line, prepended with a formatting command.

One problem with this was that one might do e.g.

    log(format("error")("A line\nAnother line"));

expecting

    ##[error]A line
    ##[error]Another line

but actually getting

    ##[error]A line
    Another line

in which case only the first line would be colored red in the log.

Now, there are two cases:

  * `endgroup`:        no argument
  * All other formats: zero or more arguments

Each of the arguments is now split at newlines; then each line is
formatted individually. It is thus on the user to ensure that they don't
pass a multiline argument if they don't want multiple formatted lines.