### PR TITLE
Fix "files" formatting in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "Pipelines",
     "vso"
   ],
-  "files": [ "dist" ],
+  "files": [
+    "dist"
+  ],
   "main": "dist/index",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
By "fix", I mean that npm enforces this formatting.