### PR TITLE
Add support for "section" format

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,6 +60,11 @@ describe(format, () => {
         const expected = `##[group]Beginning of a group`;
         expect(actual).toEqual(expected);
     });
+    it("section", () => {
+        const actual = format("section")("Start of a section");
+        const expected = `##[section]Start of a section`;
+        expect(actual).toEqual(expected);
+    });
     it("warning", () => {
         const actual = format("warning")("Warning message", "Next line", "Multiple\nLines");
         const expected = `##[warning]Warning message\n##[warning]Next line\n##[warning]Multiple\n##[warning]Lines`;

--- a/src/internal/format.ts
+++ b/src/internal/format.ts
@@ -3,6 +3,7 @@ export type FormatWithMessage =
     | "debug"
     | "error"
     | "group"
+    | "section"
     | "warning"
     ;
 


### PR DESCRIPTION
It [was added][fix] to [the docs][docs] (which I used as reference for
this library) in MicrosoftDocs/azure-devops-docs@4c98fa2 on 2021-01-08.

[docs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#formatting-commands
[fix]: https://github.com/MicrosoftDocs/azure-devops-docs/commit/4c98fa22433d0b511b5671cba4fcd71aa0120e8b